### PR TITLE
edit deck functionality

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -31,6 +31,11 @@
     -->
     <title>Studium</title>
   </head>
+  <style>
+    textarea {
+      resize: none;
+    }
+  </style>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>

--- a/src/components/cards/EditDeckCard.js
+++ b/src/components/cards/EditDeckCard.js
@@ -1,12 +1,16 @@
 import React, { useState } from 'react'
 import Flippy, { FrontSide, BackSide } from 'react-flippy'
-import { CardInput } from './styles-cards/EditDeckCardStyles'
+import { useDispatch } from 'react-redux'
+import { setCardBeingEdited } from '../../redux/actions'
+import { Link } from 'react-router-dom'
+import EditOutlinedIcon from '@material-ui/icons/EditOutlined';
 
 const cardStyle = {
    width: '335px',
    height: '98px',
    paddingTop: '10px',
    paddingLeft: '11px',
+   paddingRight: '11px',
    marginTop: '9px',
    background: '#FFFFFF',
    border: '1px solid #C4C4C4',
@@ -18,31 +22,62 @@ const cardStyle = {
    fontWeight: 'normal',
    fontSize: '18px',
    lineHeight: '23px',
+   display: 'flex',
+   justifyContent: 'space-between'
 }
 
-const EditDeckCard = ({ displayedCard, editInput }) => {
-
+const EditDeckCard = ({ displayedCard }) => {
+   const dispatch = useDispatch()
+   
+   const handleClick = () => {
+      console.log('cardToEdit from the Flipper: ', displayedCard)
+      dispatch(setCardBeingEdited(displayedCard))
+      // props.history.push(`/deck/${displayedCard.deck_id}/edit-card/${displayedCard.id}`)
+   }
+   
    return (
-      <form>
          <Flippy
             flipOnClick={true}
             flipDirection="vertical"
          >
-            <FrontSide style={cardStyle} className='flippy-front'>
-               <CardInput
-                  value={displayedCard.card_front}
-                  onChange={editInput}
-               />
-           </FrontSide>
-
-            <BackSide style={cardStyle} className='flippy-back'>
-            <CardInput
-                  value={displayedCard.card_back}
-                  onChange={editInput}
-               />
-            </BackSide>
+            
+               <FrontSide style={cardStyle} className='flippy-front'>
+               <div style={{ 
+                  height: '75px',
+                  width: '278px'
+               }}>
+                  {displayedCard.card_front}
+               </div>
+               <Link 
+                  to={`/deck/${displayedCard.deck_id}/edit-card/${displayedCard.id}`}
+                  style={{ textDecoration: 'none', color: 'grey' }}
+               >
+                  <div onClick={handleClick}>
+                     <EditOutlinedIcon color='inherit'/>
+                  </div>
+               </Link>
+               </FrontSide>
+            
+            
+            
+               <BackSide style={cardStyle} className='flippy-back'>
+               <div style={{ 
+                     height: '75px',
+                     width: '278px'
+                  }}>
+                     {displayedCard.card_back}
+                  </div>
+                  <Link 
+                     to={`/deck/${displayedCard.deck_id}/edit-card/${displayedCard.id}`}
+                     style={{ textDecoration: 'none', color: 'grey' }}
+                  >
+                     <div onClick={handleClick}>
+                        <EditOutlinedIcon />
+                     </div>
+                  </Link>
+               </BackSide>
+            
          </Flippy>
-      </form>
    )
 }
 

--- a/src/components/cards/styles-cards/CardFormStyles.js
+++ b/src/components/cards/styles-cards/CardFormStyles.js
@@ -42,6 +42,14 @@ export const AddCardFoot = styled.div`
    border-top: 1.07966px solid #C4C4C4;
 `
 
+export const EditDeckFoot = styled.div`
+   height: 80px;
+   display: flex;
+   justify-content: space-between
+   background: #FFFFFF;
+   border-top: 1.07966px solid #C4C4C4;
+`
+
 export const NextButton = styled.button`
    width: 150px;
    height: 45.44px;
@@ -55,6 +63,21 @@ export const NextButton = styled.button`
    line-height: 18px;
    color: #FFFFFF;
    border: none;
+`
+
+export const AddCardBtn = styled.button`
+   width: 150px;
+   height: 45.44px;
+   margin-top: 16px;
+   background: #FFFFFF;
+   border-radius: 6px;
+   border: 1px solid #2E71FD;
+   font-family: Source Sans Pro;
+   font-style: normal;
+   font-weight: bold;
+   font-size: 22px;
+   line-height: 18px;
+   color: #2E71FD;
 `
 
 export const ErrorMessage = styled.p`

--- a/src/components/cards/styles-cards/EditDeckCardStyles.js
+++ b/src/components/cards/styles-cards/EditDeckCardStyles.js
@@ -13,11 +13,14 @@ export const ImgIconWrapper = styled.div`
    justify-content: center;
 `
 
-export const CardInput = styled.input`
+export const CardInput = styled.textarea`
    fontFamily: Source Sans Pro;
    fontStyle: normal;
    fontWeight: normal;
    fontSize: 18px;
    lineHeight: 23px;
    border: none;
+   margin: 0;
+   width: 279px;
+   height: 60px;
 `

--- a/src/components/decks/EditDeck.js
+++ b/src/components/decks/EditDeck.js
@@ -1,13 +1,13 @@
 import React, { useState, useEffect } from 'react'
 import { useForm } from 'react-hook-form'
 import { useDispatch, useSelector } from 'react-redux'
-import { editDeck } from '../../redux/actions'
+import { editDeck, setCardBeingEdited, resetUserDecks } from '../../redux/actions'
 import { useParams, useHistory } from 'react-router-dom'
 import { MainWrapper } from '../decks/styles-decks/DeckViewStyles'
 import { InputWrapper, TextArea, AutoGen, Heading, ErrorMessage, TitleDisplay } from '../cards/styles-cards/CardFormStyles'
 import EditDeckCard from '../cards/EditDeckCard'
 import NavBarDash from '../navigation/NavBarDash'
-import EditCardFooter from '../cards/EditCardFooter'
+import EditDeckFooter from './EditDeckFooter'
 import { ImgIconWrapper } from '../cards/styles-cards/EditDeckCardStyles'
 import PanoramaOutlinedIcon from '@material-ui/icons/PanoramaOutlined'
 
@@ -22,9 +22,12 @@ const EditDeck = (props) => {
    const { register, handleSubmit, errors } = useForm()
 
    const [deckName, setDeckName] = useState();
-   const [deckToEdit, setDeckToEdit] = useState({
-      deck_name: deck.deck_name,
-      id: id,
+   const [deckToEdit, setDeckToEdit] = useState(deck)
+   const [cardToEdit, setCardToEdit] = useState({
+      card_front: '',
+      card_back: '',
+      deck_id: '',
+      id: ''
    })
 
    useEffect(() => {
@@ -41,10 +44,8 @@ const EditDeck = (props) => {
    const formSubmit = () => {
       console.log('wtf',deckToEdit)
       dispatch(editDeck(deckToEdit))
-      setDeckToEdit({
-         deck_name: null,
-         id: null
-      })
+      // dispatch(resetUserDecks(deckToEdit.user_id))
+      setDeckToEdit({})
       // if (cardToEdit.card_front !== null && cardToEdit.card_back !== null) {
       //    props.history.push(`/deck/${id}`)
       // }
@@ -72,19 +73,25 @@ const EditDeck = (props) => {
                </Heading>
                <TitleDisplay
                   style={{ boxSizing: 'boeder-box', paddingLeft: '11px'}}
+                  name='deck_name'
                   value={deckToEdit.deck_name}
                   onChange={handleChange}
                />
                <Heading style={{ marginTop: '30px' }}>
                   Cards
                </Heading>
-               {cards.map(card => {
-                  return (
-                     <EditDeckCard displayedCard={card} editInput={handleChange} />
-                  )
-               })}
+               <div style={{ marginBottom: '56px' }}>
+                  {cards.map(card => {
+                     return (
+                        <EditDeckCard 
+                           key={card.id} 
+                           displayedCard={card}
+                        />
+                     )
+                  })}
+               </div>
             </InputWrapper>
-            <EditCardFooter id={id}/>
+            <EditDeckFooter deckToEdit={deckToEdit}/>
          </form>
       </MainWrapper>
    )

--- a/src/components/decks/EditDeckFooter.js
+++ b/src/components/decks/EditDeckFooter.js
@@ -1,0 +1,34 @@
+import React from 'react'
+import { AddCardFoot, NextButton, AddCardBtn } from '../cards/styles-cards/CardFormStyles'
+import { useDispatch } from 'react-redux'
+import { Link } from 'react-router-dom'
+import { editDeck } from '../../redux/actions'
+
+const EditCardFooter = ({ deckToEdit }) => {
+   const dispatch = useDispatch()
+
+   const handleClick = e => {
+      dispatch(editDeck(deckToEdit))
+   }
+
+   return(
+      <AddCardFoot>
+         <div style={{ width: '50%' }}>
+            <Link to={`/deck/${deckToEdit.id}/create-card`}>
+               <AddCardBtn onClick={handleClick}>
+                  Add Card
+               </AddCardBtn>
+            </Link>
+         </div>
+         <div style={{ width: '50%' }}>
+            <Link to={`/deck/${deckToEdit.id}/study`}>
+               <NextButton onClick={handleClick}>
+                  Study
+               </NextButton>
+            </Link>
+         </div>
+      </AddCardFoot>
+   )
+}
+
+export default EditCardFooter

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -3,6 +3,7 @@ import AxiosWithAuth from '../utils/axiosWithAuth'
 export const GET_USER = 'GET_USER'
 export const SET_ERROR = 'SET_ERROR'
 export const SET_USER_DECKS = 'SET_USER_DECKS'
+export const RESET_USER_DECKS = 'RESET_USER_DECKS'
 export const LOGOUT = 'LOGOUT'
 export const POST_NEW_DECK = 'POST_NEW_DECK'
 export const SET_CARDS = 'SET_CARDS'
@@ -34,6 +35,18 @@ export const getUser = () => dispatch => {
       })
 }
 
+export const resetUserDecks = (id) => dispatch => {
+   AxiosWithAuth()
+      .get(`/users/${id}/decks`)
+      .then(res => {
+         dispatch({ type: RESET_USER_DECKS, payload: res.data })
+      })
+      .catch(err => {
+         console.log('NOOOOO!!!!', err)
+         dispatch({ type: SET_ERROR, payload: 'There was an error retrieving the user decks' })
+      })
+}
+
 export const postNewDeck = (deckToPost) => dispatch => {
    AxiosWithAuth()
       .post('/decks', deckToPost)
@@ -53,12 +66,17 @@ export const editDeck = (deckToEdit) => dispatch => {
       .then(res => {
          console.log(res)
          dispatch({ type: EDIT_DECK, payload: deckToEdit})
+         dispatch({ type: RESET_USER_DECKS, payload: deckToEdit})
       })
       .catch(err => {
          console.log('NOOOOO!!!!', err);
          console.log('deckToEdit', deckToEdit);
 			dispatch({ type: SET_ERROR, payload: 'error editing deck' });
 		});
+}
+
+export const setDeckBeingEdited = (deckToEdit) => dispatch => {
+   dispatch({ type: SET_EDITED_DECK, payload: deckToEdit })
 }
 
 export const postNewCard = cardToPost => dispatch => {
@@ -90,10 +108,6 @@ export const editCard = (cardToEdit) => dispatch => {
 
 export const setCardBeingEdited = (cardToEdit) => dispatch => {
    dispatch({ type: SET_EDITED_CARD, payload: cardToEdit })
-}
-
-export const setDeckBeingEdited = (deckToEdit) => dispatch => {
-   dispatch({ type: SET_EDITED_DECK, payload: deckToEdit })
 }
 
 export const logout = () => dispatch => {

--- a/src/redux/index.js
+++ b/src/redux/index.js
@@ -2,7 +2,7 @@ import { createStore, applyMiddleware } from 'redux'
 import thunk from 'redux-thunk'
 import { persistStore, persistReducer } from 'redux-persist'
 import storage from 'redux-persist/lib/storage'
-import { GET_USER, SET_ERROR, SET_USER_DECKS, LOGOUT, POST_NEW_DECK, SET_CARDS, POST_NEW_CARD, SET_EDITED_CARD, EDIT_CARD, SET_EDITED_DECK, EDIT_DECK } from './actions';
+import { GET_USER, SET_ERROR, SET_USER_DECKS, RESET_USER_DECKS, LOGOUT, POST_NEW_DECK, SET_CARDS, POST_NEW_CARD, SET_EDITED_CARD, EDIT_CARD, SET_EDITED_DECK, EDIT_DECK } from './actions';
 
 const initialState = {
    user: {},
@@ -29,6 +29,12 @@ const rootReducer = (state = initialState, action) => {
          return {
             ...state,
             userDecks: action.payload
+         }
+      case RESET_USER_DECKS:
+         const updatedUserDecks = state.userDecks.filter(deck => deck.id !== action.payload.id)
+         return {
+            ...state,
+            userDecks: [...updatedUserDecks, action.payload]
          }
       case SET_CARDS:
          return {


### PR DESCRIPTION
# Edit Deck

- From DeckView, the edit deck button now redirects to the edit deck form.
- The form prepopulates the deck/card data.
- User can directly edit the title of the deck.
- User can click on a card to flip it and see the back.
- User can click on the edit icon of a card, which will redirect the user to the edit card form (prepopulated with card data). Clicking done will take the user back to deckview.
- From Edit Deck, user can click on Add Card btn, which will redirect the user to the create card form. Clicking done will redirect the user to deckview, which will populate the updated deckCards.
- From edit deck form, user can click Study btn, which will redirect them to the study view.
- From StudyView, the DONE btn now redirects to DeckView.
- Global state is updated as the db is updated.