### PR TITLE
autoGen responce

### DIFF
--- a/src/components/cards/CreateCardForm.js
+++ b/src/components/cards/CreateCardForm.js
@@ -127,7 +127,11 @@ const CreateCardForm = (props) => {
 
                   : <TextArea
                         name='card_back' 
-                        value={autoGenRes}
+                        value={
+                           Object.keys(autoGenRes).length > 0
+                              ?  `${Object.keys(autoGenRes)[0]}`
+                              :  `${autoGenRes}`
+                        }
                         onChange={handleChange}
                         ref={register({ required: true })} 
                      />


### PR DESCRIPTION
- Trying to accurately parse the auto-gen responses
- If the response is an object with properties, the answer field now renders the first key name as a string, but not the value of the key (which is really what we want).
- We need access to the value of the key being rendered in the answer field...